### PR TITLE
Added external javax.activation dependency for newer Java versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,12 @@
 
 		<!-- Util -->
 		<dependency>
+			<groupId>com.sun.activation</groupId>
+			<artifactId>javax.activation</artifactId>
+			<version>1.2.0</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.javassist</groupId>
 			<artifactId>javassist</artifactId>
 			<version>3.19.0-GA</version>


### PR DESCRIPTION
For Java/JDK versions >8, `javax.activation` is no longer available, but has to be added as an external dependency ;)
This should fix #15 