### PR TITLE
fix(sec): upgrade com.thoughtworks.xstream:xstream to 1.4.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
 		<dependency>
 			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
-			<version>1.4.9</version>
+			<version>1.4.19</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.thoughtworks.xstream:xstream 1.4.9
- [CVE-2017-7957](https://www.oscs1024.com/hd/CVE-2017-7957)


### What did I do？
Upgrade com.thoughtworks.xstream:xstream from 1.4.9 to 1.4.19 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS